### PR TITLE
fix: Error in nested dependency cause modal initialization to break

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "prettier": "^2.8.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
+  },
+  "resolutions": {
+    "@ethereumjs/tx": "4.0.2"
   }
 }

--- a/packages/account-abstraction-kit/src/utils/deployments.ts
+++ b/packages/account-abstraction-kit/src/utils/deployments.ts
@@ -21,7 +21,7 @@ export const safeDeploymentsL1ChainIds: number[] = [
 export function getSafeContract(
   chainId: number,
   signer: ethers.Signer,
-  isL1SafeMasterCopy: boolean = false
+  isL1SafeMasterCopy = false
 ): GnosisSafe {
   const filters: DeploymentFilter = {
     version: '1.3.0', // Only Safe v1.3.0 supported so far

--- a/packages/onramp-kit/example/client/src/AppBar.tsx
+++ b/packages/onramp-kit/example/client/src/AppBar.tsx
@@ -1,8 +1,6 @@
 import { AppBar as MuiAppBar, Typography, styled } from '@mui/material'
 
-type AppBarProps = {}
-
-const AppBar = (props: AppBarProps) => {
+const AppBar = () => {
   return (
     <StyledAppBar position="static" color="default">
       <Typography variant="h3" pl={4} fontWeight={700}>

--- a/packages/onramp-kit/src/types/declarations.d.ts
+++ b/packages/onramp-kit/src/types/declarations.d.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line
 declare var StripeOnramp: any

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,13 +40,6 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz#3639df0e1435cab03f4d9870cc3ac079e57a6fc9"
   integrity sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==
 
-"@chainsafe/persistent-merkle-tree@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz#4c9ee80cc57cd3be7208d98c40014ad38f36f7ff"
-  integrity sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==
-  dependencies:
-    "@chainsafe/as-sha256" "^0.3.1"
-
 "@chainsafe/persistent-merkle-tree@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz#2b4a62c9489a5739dedd197250d8d2f5427e9f63"
@@ -61,15 +54,6 @@
   dependencies:
     "@chainsafe/as-sha256" "^0.3.1"
     "@chainsafe/persistent-merkle-tree" "^0.5.0"
-
-"@chainsafe/ssz@^0.9.2":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.9.4.tgz#696a8db46d6975b600f8309ad3a12f7c0e310497"
-  integrity sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==
-  dependencies:
-    "@chainsafe/as-sha256" "^0.3.1"
-    "@chainsafe/persistent-merkle-tree" "^0.4.2"
-    case "^1.6.3"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -93,7 +77,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@ethereumjs/common@^3.0.2", "@ethereumjs/common@^3.1.0":
+"@ethereumjs/common@^3.0.2":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-3.1.0.tgz#33eca566d19a7555d905edeeef36a2cc55afc355"
   integrity sha512-LyfDb6i4AJ9sSuFY+sz1HQwjSZkIrEuYjrqUO2d3ESzvc8pQwKkrqk19dlNxIMNP3Q5SJ+fqeLOun7R4HJYKdQ==
@@ -101,22 +85,21 @@
     "@ethereumjs/util" "^8.0.4"
     crc-32 "^1.2.0"
 
-"@ethereumjs/rlp@^4.0.1":
+"@ethereumjs/rlp@^4.0.0", "@ethereumjs/rlp@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.1.tgz#626fabfd9081baab3d0a3074b0c7ecaf674aaa41"
   integrity sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==
 
-"@ethereumjs/tx@^4.0.2":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-4.1.0.tgz#02357c4f307b988abe7870126241c140c7ecc375"
-  integrity sha512-3/PawJxcmI0LR8SCqN/3OTz76Q4Mhto8TCvcTpIAPx/l9V68C/NBjYdJOn2WshzxRvvm6jBTphUaZc2B70W5Jw==
+"@ethereumjs/tx@4.0.2", "@ethereumjs/tx@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-4.0.2.tgz#082b0f95fe9a61c70277ee1bfeb65d6f27a723bb"
+  integrity sha512-6GoKVK3MVcAFFn4qSLIIDZ1vrKSLn7W5L80Pvae1BJFgchu+11R2iOqQyVGUSGbaXllh4xliUy/7+x5pYwRY8Q==
   dependencies:
-    "@chainsafe/ssz" "^0.9.2"
-    "@ethereumjs/common" "^3.1.0"
-    "@ethereumjs/rlp" "^4.0.1"
-    "@ethereumjs/util" "^8.0.4"
-    "@ethersproject/providers" "^5.7.2"
+    "@ethereumjs/common" "^3.0.2"
+    "@ethereumjs/rlp" "^4.0.0"
+    "@ethereumjs/util" "^8.0.3"
     ethereum-cryptography "^1.1.2"
+    ethers "^5.7.1"
 
 "@ethereumjs/util@^8.0.0", "@ethereumjs/util@^8.0.3", "@ethereumjs/util@^8.0.4":
   version "8.0.4"
@@ -318,7 +301,7 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.7.2":
+"@ethersproject/providers@5.7.2":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -2446,11 +2429,6 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-case@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
-  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
-
 chalk@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -3421,7 +3399,7 @@ ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@5.7.2, ethers@^5.7.2:
+ethers@5.7.2, ethers@^5.7.1, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
## What it solves
There is an [open bug](https://github.com/Web3Auth/web3auth-web/issues/1372) in the web3auth repo due to the `c-kzg` package which is a nested dependency of `@web3auth/openlogin-adapter`. This cause the `initModal()` method to fail

We add a resolution in the root package.json in order to fix it

