### PR TITLE
Use createTransaction from protocol-kit in createRelayedTransaction

### DIFF
--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -1,11 +1,11 @@
+import { RelayAdapter } from '@safe-global/relay-kit'
 import Safe from '@safe-global/safe-core-sdk'
-import { BigNumber, ethers } from 'ethers'
+import EthersAdapter from '@safe-global/safe-ethers-lib'
+import { ethers } from 'ethers'
 import { GnosisSafe__factory } from '../typechain/factories'
 import { GnosisSafe } from '../typechain/GnosisSafe'
 import { MultiSendCallOnly } from '../typechain/libraries'
 import { GnosisSafeProxyFactory } from '../typechain/proxies'
-import { RelayAdapter } from '@safe-global/relay-kit'
-import EthersAdapter from '@safe-global/safe-ethers-lib'
 import {
   AccountAbstractionConfig,
   MetaTransactionData,
@@ -87,7 +87,7 @@ class AccountAbstraction {
   }
 
   async relayTransaction(
-    transaction: MetaTransactionData,
+    transactions: MetaTransactionData[],
     options: MetaTransactionOptions
   ): Promise<string> {
     if (
@@ -100,25 +100,26 @@ class AccountAbstraction {
       throw new Error('SDK not initialized')
     }
 
+    const safeAddress = this.getSafeAddress()
+
     const ethAdapter = new EthersAdapter({
       ethers,
       signerOrProvider: this.#signer
     })
-
     const safe = await Safe.create({
       ethAdapter,
-      safeAddress: this.getSafeAddress()
+      safeAddress
     })
 
     const standardizedSafeTx = await this.#relayAdapter.createRelayedTransaction(
-      transaction,
       safe,
+      transactions,
       options
     )
 
     const signature = await getSignature(
       this.#signer,
-      this.getSafeAddress(),
+      safeAddress,
       standardizedSafeTx,
       this.#chainId
     )

--- a/packages/account-abstraction-kit/src/AccountAbstraction.ts
+++ b/packages/account-abstraction-kit/src/AccountAbstraction.ts
@@ -120,12 +120,12 @@ class AccountAbstraction {
     const signature = await getSignature(
       this.#signer,
       safeAddress,
-      standardizedSafeTx,
+      standardizedSafeTx.data,
       this.#chainId
     )
     const transactionData = await encodeExecTransaction(
       this.#safeContract,
-      standardizedSafeTx,
+      standardizedSafeTx.data,
       signature
     )
 

--- a/packages/relay-kit/README.md
+++ b/packages/relay-kit/README.md
@@ -8,8 +8,7 @@ The Relay Kit allows to abstract users from the transaction fees payment (gas fe
 
 ## Reference
 
-  - [Relay Kit docs](https://docs.safe.global/learn/safe-core-account-abstraction-sdk/relay-kit)
-
+- [Relay Kit docs](https://docs.safe.global/learn/safe-core-account-abstraction-sdk/relay-kit)
 
 ## License
 

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayAdapter.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayAdapter.ts
@@ -8,7 +8,7 @@ import {
   TransactionStatusResponse
 } from '@gelatonetwork/relay-sdk'
 import Safe from '@safe-global/safe-core-sdk'
-import { MetaTransactionData, SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+import { MetaTransactionData, SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { GELATO_FEE_COLLECTOR, GELATO_NATIVE_TOKEN_ADDRESS, ZERO_ADDRESS } from '../../constants'
 import { MetaTransactionOptions, RelayAdapter, RelayTransaction } from '../../types'
 
@@ -56,7 +56,7 @@ export class GelatoRelayAdapter implements RelayAdapter {
     safe: Safe,
     transactions: MetaTransactionData[],
     options: MetaTransactionOptions
-  ): Promise<SafeTransactionData> {
+  ): Promise<SafeTransaction> {
     const { gasLimit, gasToken, isSponsored } = options
     const chainId = await safe.getChainId()
     const estimation = await this.getEstimateFee(chainId, gasLimit, gasToken)
@@ -72,7 +72,7 @@ export class GelatoRelayAdapter implements RelayAdapter {
         nonce
       }
     })
-    return relayedSafeTransaction.data
+    return relayedSafeTransaction
   }
 
   async sponsorTransaction(

--- a/packages/relay-kit/src/packs/gelato/GelatoRelayAdapter.ts
+++ b/packages/relay-kit/src/packs/gelato/GelatoRelayAdapter.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import Safe, { standardizeSafeTransactionData } from '@safe-global/safe-core-sdk'
 import {
   CallWithSyncFeeRequest,
   GelatoRelay as GelatoNetworkRelay,
@@ -8,7 +7,8 @@ import {
   SponsoredCallRequest,
   TransactionStatusResponse
 } from '@gelatonetwork/relay-sdk'
-import { SafeTransactionData, MetaTransactionData } from '@safe-global/safe-core-sdk-types'
+import Safe from '@safe-global/safe-core-sdk'
+import { MetaTransactionData, SafeTransactionData } from '@safe-global/safe-core-sdk-types'
 import { GELATO_FEE_COLLECTOR, GELATO_NATIVE_TOKEN_ADDRESS, ZERO_ADDRESS } from '../../constants'
 import { MetaTransactionOptions, RelayAdapter, RelayTransaction } from '../../types'
 
@@ -53,30 +53,26 @@ export class GelatoRelayAdapter implements RelayAdapter {
   }
 
   async createRelayedTransaction(
-    transaction: MetaTransactionData,
     safe: Safe,
+    transactions: MetaTransactionData[],
     options: MetaTransactionOptions
   ): Promise<SafeTransactionData> {
     const { gasLimit, gasToken, isSponsored } = options
     const chainId = await safe.getChainId()
     const estimation = await this.getEstimateFee(chainId, gasLimit, gasToken)
-
     const nonce = await this._getSafeNonce(safe)
 
-    const standardizedSafeTx = await standardizeSafeTransactionData(
-      safe.getContractManager().safeContract,
-      safe.getEthAdapter(),
-      {
-        ...transaction,
+    const relayedSafeTransaction = await safe.createTransaction({
+      safeTransactionData: transactions,
+      options: {
         baseGas: !isSponsored ? estimation.toNumber() : 0,
         gasPrice: !isSponsored ? 1 : 0,
         gasToken: gasToken ?? ZERO_ADDRESS,
         refundReceiver: !isSponsored ? this.getFeeCollector() : ZERO_ADDRESS,
         nonce
       }
-    )
-
-    return standardizedSafeTx
+    })
+    return relayedSafeTransaction.data
   }
 
   async sponsorTransaction(

--- a/packages/relay-kit/src/types.ts
+++ b/packages/relay-kit/src/types.ts
@@ -1,7 +1,7 @@
 import { RelayResponse, TransactionStatusResponse } from '@gelatonetwork/relay-sdk'
-import { BigNumber } from 'ethers'
 import Safe from '@safe-global/safe-core-sdk'
 import { MetaTransactionData, SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+import { BigNumber } from 'ethers'
 
 // TO-DO: Duplicated. Remove local type and import from "types" package
 // {
@@ -17,8 +17,8 @@ export interface RelayAdapter {
   getEstimateFee(chainId: number, gasLimit: BigNumber, gasToken?: string): Promise<BigNumber>
   getTaskStatus(taskId: string): Promise<TransactionStatusResponse | undefined>
   createRelayedTransaction(
-    transaction: MetaTransactionData,
     safe: Safe,
+    transactions: MetaTransactionData[],
     options: MetaTransactionOptions
   ): Promise<SafeTransactionData>
   relayTransaction(transaction: RelayTransaction): Promise<RelayResponse>

--- a/packages/relay-kit/src/types.ts
+++ b/packages/relay-kit/src/types.ts
@@ -1,6 +1,6 @@
 import { RelayResponse, TransactionStatusResponse } from '@gelatonetwork/relay-sdk'
 import Safe from '@safe-global/safe-core-sdk'
-import { MetaTransactionData, SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+import { MetaTransactionData, SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { BigNumber } from 'ethers'
 
 // TO-DO: Duplicated. Remove local type and import from "types" package
@@ -20,7 +20,7 @@ export interface RelayAdapter {
     safe: Safe,
     transactions: MetaTransactionData[],
     options: MetaTransactionOptions
-  ): Promise<SafeTransactionData>
+  ): Promise<SafeTransaction>
   relayTransaction(transaction: RelayTransaction): Promise<RelayResponse>
 }
 

--- a/playground/relay-kit/paid-transaction.ts
+++ b/playground/relay-kit/paid-transaction.ts
@@ -26,7 +26,7 @@ const mockOnRampConfig = {
 const txConfig = {
   TO: '<TO>',
   DATA: '<DATA>',
-  VALUE: BigNumber.from('<VALUE>'),
+  VALUE: '<VALUE>',
   // Options:
   GAS_LIMIT: BigNumber.from('<GAS_LIMIT>'),
   GAS_TOKEN: ethers.constants.AddressZero
@@ -77,9 +77,7 @@ async function main() {
       to: predictedSafeAddress,
       value: fundingAmount
     })
-    console.log(
-      `Funding the Safe with ${ethers.utils.formatEther(fundingAmount.toString())} ETH`
-    )
+    console.log(`Funding the Safe with ${ethers.utils.formatEther(fundingAmount.toString())} ETH`)
     await onRampResponse.wait()
 
     const safeBalanceAfter = await provider.getBalance(predictedSafeAddress)
@@ -88,18 +86,20 @@ async function main() {
 
   // Relay the transaction
 
-  const safeTransaction: MetaTransactionData = {
-    to: txConfig.TO,
-    data: txConfig.DATA,
-    value: txConfig.VALUE,
-    operation: OperationType.Call
-  }
+  const safeTransactions: MetaTransactionData[] = [
+    {
+      to: txConfig.TO,
+      data: txConfig.DATA,
+      value: txConfig.VALUE,
+      operation: OperationType.Call
+    }
+  ]
   const options: MetaTransactionOptions = {
     gasLimit: txConfig.GAS_LIMIT,
     gasToken: txConfig.GAS_TOKEN
   }
 
-  const response = await safeAccountAbstraction.relayTransaction(safeTransaction, options)
+  const response = await safeAccountAbstraction.relayTransaction(safeTransactions, options)
   console.log({ GelatoTaskId: response })
 }
 

--- a/playground/relay-kit/sponsored-transaction.ts
+++ b/playground/relay-kit/sponsored-transaction.ts
@@ -30,7 +30,7 @@ const mockOnRampConfig = {
 const txConfig = {
   TO: '<TO>',
   DATA: '<DATA>',
-  VALUE: BigNumber.from('<VALUE>'),
+  VALUE: '<VALUE>',
   // Options:
   GAS_LIMIT: BigNumber.from('<GAS_LIMIT>')
 }
@@ -69,9 +69,7 @@ async function main() {
       to: predictedSafeAddress,
       value: txConfig.VALUE
     })
-    console.log(
-      `Funding the Safe with ${ethers.utils.formatEther(txConfig.VALUE.toString())} ETH`
-    )
+    console.log(`Funding the Safe with ${ethers.utils.formatEther(txConfig.VALUE.toString())} ETH`)
     await onRampResponse.wait()
 
     const safeBalanceAfter = await provider.getBalance(predictedSafeAddress)
@@ -80,18 +78,20 @@ async function main() {
 
   // Relay the transaction
 
-  const safeTransaction: MetaTransactionData = {
-    to: txConfig.TO,
-    data: txConfig.DATA,
-    value: txConfig.VALUE,
-    operation: OperationType.Call
-  }
+  const safeTransactions: MetaTransactionData[] = [
+    {
+      to: txConfig.TO,
+      data: txConfig.DATA,
+      value: txConfig.VALUE,
+      operation: OperationType.Call
+    }
+  ]
   const options: MetaTransactionOptions = {
     gasLimit: txConfig.GAS_LIMIT,
     isSponsored: true
   }
 
-  const response = await safeAccountAbstraction.relayTransaction(safeTransaction, options)
+  const response = await safeAccountAbstraction.relayTransaction(safeTransactions, options)
   console.log({ GelatoTaskId: response })
 }
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/account-abstraction-sdk/issues/25

## How this PR fixes it

Currently we based the `createRelayedTransaction` to do a similar behavior as the `createTransaction` from the `protocol-kit`. Ideally the createRelayedTransaction should use the complete `createTransaction` in the background as this way the logic regarding batched transactions will be also available on the Relayed method without explicit implementation.