### PR TITLE
fix subscriber types

### DIFF
--- a/packages/auth-kit/src/SafeAuthKit.ts
+++ b/packages/auth-kit/src/SafeAuthKit.ts
@@ -124,7 +124,7 @@ export default class SafeAuthKit extends EventEmitter {
    * @param eventName The event name to subscribe to. Choose from SafeAuthEvents type
    * @param listener The callback function to be called when the event is emitted
    */
-  subscribe(eventName: typeof SafeAuthEvents, listener: (...args: any[]) => void) {
+  subscribe(eventName: typeof keyof SafeAuthEvents, listener: (...args: any[]) => void) {
     this.on(eventName.toString(), listener)
   }
 
@@ -133,7 +133,7 @@ export default class SafeAuthKit extends EventEmitter {
    * @param eventName The event name to unsubscribe from. Choose from SafeAuthEvents type
    * @param listener The callback function to unsubscribe
    */
-  unsubscribe(eventName: typeof SafeAuthEvents, listener: (...args: any[]) => void) {
+  unsubscribe(eventName: typeof keyof SafeAuthEvents, listener: (...args: any[]) => void) {
     this.off(eventName.toString(), listener)
   }
 


### PR DESCRIPTION
## What it solves
Right now typescript throws an error when you call"

```
safeAuthKit.subscribe('SIGN_IN', () => {...})
```
because the function is incorrectly typed

## How this PR fixes it
* Fix types
